### PR TITLE
Improved parameters for testnet.bash

### DIFF
--- a/testnet.bash
+++ b/testnet.bash
@@ -94,12 +94,6 @@ EOF
 
 function run_miner() {
     MINER_INDEX=$1
-    JSONRPC_PORT=$2
-    if [ -z "$JSONRPC_PORT" ]
-    then
-        JSONRPC_PORT=0
-    fi
-
     PASSWORD_FILE="$TESTNET_BASE_DIR/password.txt"
     if [ ! -f "$PASSWORD_FILE" ]
     then
@@ -145,9 +139,6 @@ function run_miner() {
             --miner.etherbase="$MINER_ADDRESS" \
             --networkid=1337 \
             --port 0 \
-            --http.api eth \
-            --http.addr 0.0.0.0 \
-            --http.port "$JSONRPC_PORT" \
             >>"$MINER_LOGFILE" 2>&1 \
             &
         set +x
@@ -161,11 +152,8 @@ function run_miner() {
             --miner.gasprice=1000 \
             --miner.etherbase="$MINER_ADDRESS" \
             --networkid=1337 \
-            --port "$JSONRPC_PORT" \
+            --port 0 \
             --bootnodes "$BOOTNODE" \
-            --http.api eth \
-            --http.addr 0.0.0.0 \
-            --http.port "$JSONRPC_PORT" \
             >>"$MINER_LOGFILE" 2>&1 \
             &
         set +x


### PR DESCRIPTION
<!-- Thank you for your contribution. -->
<!-- Filling in the sections below will provide us with some context when we are reviewing your pull request. -->

## Changes

- Added a usage string for `testnet.bash -h`
- Chain ID can now be passed using the `GENESIS_JSON_CHAIN_ID` environment variable.
- `trap` now exits also from `SIGTERM` and `SIGKILL`.

<!-- Please leave a short description of the changes you have made in this pull request. -->
<!-- If applicable, this is the place to discuss alternatives you considered and tradeoffs you made. -->

## How to test these changes?

Just run `./testnet.bash -h`.

<!-- Describe how you tested the changes in this pull request. -->
<!-- Describe how someone else could reproduce your tests. -->

## Related issues

<!-- Is this PR related to any of the issues at https://github.com/orgs/bugout-dev/projects/3 ? -->
<!-- If this PR resolves any of those issues, add a line in the format "Resolves <link to isssue>". -->

<!-- Thanks again! :) -->
